### PR TITLE
Enable searrrch to parse text with hashtag

### DIFF
--- a/lib/searrrch.rb
+++ b/lib/searrrch.rb
@@ -9,7 +9,7 @@ class Searrrch
   #   2. then look for word characters.. supporting Japanese, Korean, Chinese and latin alphabet plus numbers and such
   #      also support ',' for you cool kids that expect something like a "list of ids"
   #   3. and also accept any char if quoted - in which case the same quotation should be quoted as well
-  OPERATOR_EXPRESSION = /(\w+):[\ 　]?([\w\p{Han}\p{Katakana}\p{Hiragana}\p{Hangul}ー,]+|(["'])(\\?.)*?\3)/
+  OPERATOR_EXPRESSION = /(\w+):[\ 　]?([\w\p{Han}\p{Katakana}\p{Hiragana}\p{Hangul}#ー,]+|(["'])(\\?.)*?\3)/
 
 
   # iterates over the entire string identifying each of the elements

--- a/spec/operators_spec.rb
+++ b/spec/operators_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe 'operators' do
     end
   end
 
+  it 'has text with # ' do
+    query = 'hashtag: #hashtag,#hashtag2'
+    search = Searrrch.new query, true
+    expect(search.to_array(:hashtag)).to eq %w(#hashtag #hashtag2)
+  end
+
   it 'only one as \"rails model\"' do
     module FakeModel
       def self.find(id)


### PR DESCRIPTION
Make searrrch enable to parse text with hashtag like this.

```rb
Searrrch.new('some_key:#with_hashtag')
#<Searrrch:0x007fdffa064eb0 @operators={:some_key=>["#with_hashtag"]}, @freetext="">
```